### PR TITLE
Upgrade CI to node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:16
     steps:
       - checkout
       - run:
@@ -11,10 +11,10 @@ jobs:
       - run:
           name: Build Application
           command: yarn build
-          
+
   deploy:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:16
     steps:
       - checkout
       - run:


### PR DESCRIPTION
# Issue
Node.JS 12 is too old, 16 is okay to use with this project

# Things done
Bumped node to 16 in build execution environment